### PR TITLE
Set schema builder connection

### DIFF
--- a/src/Sanitizable.php
+++ b/src/Sanitizable.php
@@ -55,7 +55,7 @@ trait Sanitizable {
                         ? $fillable 
                         : array_diff(
                             array_diff(
-                                Schema::getColumnListing($this->getTable()), 
+                                Schema::connection($this->getConnectionName())->getColumnListing($this->getTable()), 
                                 $this->getGuarded()
                             ), 
                             $this->getHidden()


### PR DESCRIPTION
Set schema builder connection to the same connection as the model when sanitizing the data.

This makes the package compatible with multiple multi-tenancy packages which change the database connection dynamically. 